### PR TITLE
Twisted Postgres client

### DIFF
--- a/clients/twisted-postgres/main.py
+++ b/clients/twisted-postgres/main.py
@@ -1,0 +1,17 @@
+import json
+from twisted.internet import reactor
+from txpostgres import txpostgres
+
+BENTHAM_PG_NOTIFY_CHANNEL = 'bentham_events'
+
+def observer(notify):
+    print json.dumps(json.loads(notify.payload), indent=4)
+
+if __name__ == '__main__':
+    conn = txpostgres.Connection()
+    d = conn.connect()
+
+    conn.addNotifyObserver(observer)
+    d.addCallback(lambda _: conn.runOperation('LISTEN %s' % BENTHAM_PG_NOTIFY_CHANNEL))
+
+    reactor.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,7 @@ python-twitter==2.2
 requests==2.7.0
 requests-oauthlib==0.5.0
 simplejson==3.8.0
-SQLAlchemy==1.0.8
+Twisted==15.4.0
+txpostgres==1.5.0
 wheel==0.24.0
+zope.interface==4.1.3


### PR DESCRIPTION
I've got a simple, functioning implementation of a twisted postgres client. It adds a trigger to the events table that sends a `NOTIFY` on the `bentham_events` channel on insert, and passes the entire row along with it.

This needs to have a few things done before it can be merged:
- [ ] Properly fetch configs for database connection
- [ ] Setup as a proper twistd daemon
- [ ] Include PG trigger to send NOTIFY on inserts

This is the postgres code needed to setup the trigger:

```
CREATE OR REPLACE FUNCTION bentham_event_notify() RETURNS trigger AS $$
BEGIN
  PERFORM pg_notify('bentham_events', to_json(NEW)::text);
  RETURN NEW;
END;
$$ LANGUAGE plpgsql;

CREATE TRIGGER bentham_new_event
AFTER INSERT ON events
FOR EACH ROW
EXECUTE PROCEDURE bentham_event_notify();
```

I'm not sure exactly how we're orchestrating the database yet, as the schema is not created initially. I think we need some form of setup step.
